### PR TITLE
Obtain only the files ending in ".sql" in the Path directory

### DIFF
--- a/src/db_dialect.erl
+++ b/src/db_dialect.erl
@@ -9,7 +9,7 @@
 init() ->
     "CREATE TABLE IF NOT EXISTS database_migrations_history (
     version INTEGER NOT NULL PRIMARY KEY,
-    filename TEXT NOT NULL,
+    filename varchar(255) NOT NULL,
     creation_timestamp TIMESTAMP NOT NULL DEFAULT NOW()
         )".
 


### PR DESCRIPTION

1. Obtain only the files ending in ".sql" in the Path directory
2. run erlang/otp 25.3.2.12 ; epgsql 4.7.1; PostgreSQL 15.7 (Debian 15.7-1.pgdg110+1)

Why add this submission:
For example, on my computer, the system automatically generated file .DS_Store caused the unexpected_version exception

filelib:wildcard/1 doesn't recurse subdirectories, but I feel like that's enough